### PR TITLE
Restore capitalisation in Selections bridgeheads

### DIFF
--- a/src/epub/text/selections-from-the-principles-of-philosophy.xhtml
+++ b/src/epub/text/selections-from-the-principles-of-philosophy.xhtml
@@ -139,14 +139,14 @@
 					<section id="selections-from-the-principles-of-philosophy-1-13" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XIII</h5>
-							<p epub:type="bridgehead">In what sense the knowledge of other things depends upon the knowledge of god.</p>
+							<p epub:type="bridgehead">In what sense the knowledge of other things depends upon the knowledge of God.</p>
 						</header>
 						<p>But when the mind, which thus knows itself but is still in doubt as to all other things, looks around on all sides, with a view to the farther extension of its knowledge, it first of all discovers within itself the ideas of many things; and while it simply contemplates them, and neither affirms nor denies that there is anything beyond itself corresponding to them, it is in no danger of erring. The mind also discovers certain common notions out of which it frames various demonstrations that carry conviction to such a degree as to render doubt of their truth impossible, so long as we give attention to them. For example, the mind has within itself ideas of numbers and figures, and it has likewise among its common notions the principle “that if equals be added to equals the wholes will be equal,” and the like; from which it is easy to demonstrate that the three angles of a triangle are equal to two right angles, <abbr class="eoc">etc.</abbr> Now, so long as we attend to the premises from which this conclusion and others similar to it were deduced, we feel assured of their truth; but, as the mind cannot always think of these with attention, when it has the remembrance of a conclusion without recollecting the order of its deduction, and is uncertain whether the author of its being has created it of a nature that is liable to be deceived, even in what appears most evident, it perceives that there is just ground to distrust the truth of such conclusions, and that it cannot possess any certain knowledge until it has discovered its author.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-14" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XIV</h5>
-							<p epub:type="bridgehead">That we may validly infer the existence of god from necessary existence being comprised in the concept we have of him.</p>
+							<p epub:type="bridgehead">That we may validly infer the existence of God from necessary existence being comprised in the concept we have of him.</p>
 						</header>
 						<p>When the mind afterwards reviews the different ideas that are in it, it discovers what is by far the chief among them⁠—that of a Being omniscient, all-powerful, and absolutely perfect; and it observes that in this idea there is contained not only possible and contingent existence, as in the ideas of all other things which it clearly perceives, but existence absolutely necessary and eternal. And just as because, for example, the equality of its three angles to two right angles is necessarily comprised in the idea of a triangle, the mind is firmly persuaded that the three angles of a triangle are equal to two right angles; so, from its perceiving necessary and eternal existence to be comprised in the idea which it has of an all-perfect Being, it ought manifestly to conclude that this all-perfect Being exists.</p>
 					</section>
@@ -160,7 +160,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-16" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XVI</h5>
-							<p epub:type="bridgehead">That prejudices hinder many from clearly knowing the necessity of the existence of god.</p>
+							<p epub:type="bridgehead">That prejudices hinder many from clearly knowing the necessity of the existence of God.</p>
 						</header>
 						<p>Our mind would have no difficulty in assenting to this truth, if it were, first of all, wholly free from prejudices; but as we have been accustomed to distinguish, in all other things, essence from existence, and to imagine at will many ideas of things which neither are nor have been, it easily happens, when we do not steadily fix our thoughts on the contemplation of the all-perfect Being, that a doubt arises as to whether the idea we have of him is not one of those which we frame at pleasure, or at least of that class to whose essence existence does not pertain.</p>
 					</section>
@@ -174,56 +174,56 @@
 					<section id="selections-from-the-principles-of-philosophy-1-18" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XVIII</h5>
-							<p epub:type="bridgehead">That the existence of god may be again inferred from the above.</p>
+							<p epub:type="bridgehead">That the existence of God may be again inferred from the above.</p>
 						</header>
 						<p>Thus, because we discover in our minds the idea of God, or of an all-perfect Being, we have a right to inquire into the source whence we derive it; and we will discover that the perfections it represents are so immense as to render it quite certain that we could only derive it from an all-perfect Being; that is, from a God really existing. For it is not only manifest by the natural light that nothing cannot be the cause of anything whatever, and that the more perfect cannot arise from the less perfect, so as to be thereby produced as by its efficient and total cause, but also that it is impossible we can have the idea or representation of anything whatever, unless there be somewhere, either in us or out of us, an original which comprises, in reality, all the perfections that are thus represented to us; but, as we do not in any way find in ourselves those absolute perfections of which we have the idea, we must conclude that they exist in some nature different from ours, that is, in God, or at least that they were once in him; and it most manifestly follows [from their infinity] that they are still there.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-19" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XIX</h5>
-							<p epub:type="bridgehead">That, although we may not comprehend the nature of god, there is yet nothing which we know so clearly as his perfections.</p>
+							<p epub:type="bridgehead">That, although we may not comprehend the nature of God, there is yet nothing which we know so clearly as his perfections.</p>
 						</header>
 						<p>This will appear sufficiently certain and manifest to those who have been accustomed to contemplate the idea of God, and to turn their thoughts to his infinite perfections; for, although we may not comprehend them, because it is of the nature of the infinite not to be comprehended by what is finite, we nevertheless conceive them more clearly and distinctly than material objects, for this reason, that, being simple, and unobscured by limits,<a href="endnotes.xhtml#note-19" id="noteref-19" epub:type="noteref">19</a> they occupy our mind more fully.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-20" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XX</h5>
-							<p epub:type="bridgehead">That we are not the cause of ourselves, but that this is god, and consequently that there is a god.</p>
+							<p epub:type="bridgehead">That we are not the cause of ourselves, but that this is God, and consequently that there is a God.</p>
 						</header>
 						<p>But, because everyone has not observed this, and because, when we have an idea of any machine in which great skill is displayed, we usually know with sufficient accuracy the manner in which we obtained it, and as we cannot even recollect when the idea we have of a God was communicated to us by him, seeing it was always in our minds, it is still necessary that we should continue our review, and make inquiry after our author, possessing, as we do, the idea of the infinite perfections of a God: for it is in the highest degree evident by the natural light, that that which knows something more perfect than itself, is not the source of its own being, since it would thus have given to itself all the perfections which it knows; and that, consequently, it could draw its origin from no other being than from him who possesses in himself all those perfections, that is, from God.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-21" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXI</h5>
-							<p epub:type="bridgehead">That the duration alone of our life is sufficient to demonstrate the existence of god.</p>
+							<p epub:type="bridgehead">That the duration alone of our life is sufficient to demonstrate the existence of God.</p>
 						</header>
 						<p>The truth of this demonstration will clearly appear, provided we consider the nature of time, or the duration of things; for this is of such a kind that its parts are not mutually dependent, and never coexistent; and, accordingly, from the fact that we now are, it does not necessarily follow that we shall be a moment afterwards, unless some cause, <abbr>viz.</abbr>, that which first produced us, shall, as it were, continually reproduce us, that is, conserve us. For we easily understand that there is no power in us by which we can conserve ourselves, and that the being who has so much power as to conserve us out of himself, must also by so much the greater reason conserve himself, or rather stand in need of being conserved by no one whatever, and, in fine, be God.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-22" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXII</h5>
-							<p epub:type="bridgehead">That in knowing the existence of god, in the manner here explained, we likewise know all his attributes, as far as they can be known by the natural light alone.</p>
+							<p epub:type="bridgehead">That in knowing the existence of God, in the manner here explained, we likewise know all his attributes, as far as they can be known by the natural light alone.</p>
 						</header>
 						<p>There is the great advantage in proving the existence of God in this way, <abbr>viz.</abbr>, by his idea, that we at the same time know what he is, as far as the weakness of our nature allows; for, reflecting on the idea we have of him which is born with us, we perceive that he is eternal, omniscient, omnipotent, the source of all goodness and truth, creator of all things, and that, in fine, he has in himself all that in which we can clearly discover any infinite perfection or good that is not limited by any imperfection.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-23" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXIII</h5>
-							<p epub:type="bridgehead">That god is not corporeal, and does not perceive by means of senses as we do, or will the evil of sin.</p>
+							<p epub:type="bridgehead">That God is not corporeal, and does not perceive by means of senses as we do, or will the evil of sin.</p>
 						</header>
 						<p>For there are indeed many things in the world that are to a certain extent imperfect or limited, though possessing also some perfection; and it is accordingly impossible that any such can be in God. Thus, looking to corporeal nature,<a href="endnotes.xhtml#note-20" id="noteref-20" epub:type="noteref">20</a> since divisibility is included in local extension, and this indicates imperfection, it is certain that God is not body. And although in men it is to some degree a perfection to be capable of perceiving by means of the senses, nevertheless since in every sense there is passivity<a href="endnotes.xhtml#note-21" id="noteref-21" epub:type="noteref">21</a> which indicates dependency, we must conclude that God is in no manner possessed of senses, and that he only understands and wills, not, however, like us, by acts in any way distinct, but always by an act that is one, identical, and the simplest possible, understands, wills, and operates all, that is, all things that in reality exist; for he does not will the evil of sin, seeing this is but the negation of being.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-24" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXIV</h5>
-							<p epub:type="bridgehead">That in passing from the knowledge of god to the knowledge of the creatures, it is necessary to remember that our understanding is finite, and the power of god infinite.</p>
+							<p epub:type="bridgehead">That in passing from the knowledge of God to the knowledge of the creatures, it is necessary to remember that our understanding is finite, and the power of God infinite.</p>
 						</header>
 						<p>But as we know that God alone is the true cause of all that is or can be, we will doubtless follow the best way of philosophizing, if, from the knowledge we have of God himself, we pass to the explication of the things which he has created, and essay to deduce it from the notions that are naturally in our minds, for we will thus obtain the most perfect science, that is, the knowledge of effects through their causes. But that we may be able to make this attempt with sufficient security from error, we must use the precaution to bear in mind as much as possible that God, who is the author of things, is infinite, while we are wholly finite.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-1-25" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXV</h5>
-							<p epub:type="bridgehead">That we must believe all that god has revealed, although it may surpass the reach of our faculties.</p>
+							<p epub:type="bridgehead">That we must believe all that God has revealed, although it may surpass the reach of our faculties.</p>
 						</header>
 						<p>Thus, if perhaps God reveal to us or others, matters concerning himself which surpass the natural powers of our mind, such as the mysteries of the incarnation and of the trinity, we will not refuse to believe them, although we may not clearly understand them; nor will we be in any way surprised to find in the immensity of his nature, or even in what he has created, many things that exceed our comprehension.</p>
 					</section>
@@ -251,7 +251,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-29" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXIX</h5>
-							<p epub:type="bridgehead">That god is not the cause of our errors.</p>
+							<p epub:type="bridgehead">That God is not the cause of our errors.</p>
 						</header>
 						<p>The first attribute of God which here falls to be considered, is that he is absolutely veracious and the source of all light, so that it is plainly repugnant for him to deceive us, or to be properly and positively the cause of the errors to which we are consciously subject; for although the address to deceive seems to be some mark of subtlety of mind among men, yet without doubt the will to deceive only proceeds from malice or from fear and weakness, and consequently cannot be attributed to God.</p>
 					</section>
@@ -265,7 +265,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-31" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXXI</h5>
-							<p epub:type="bridgehead">That our errors are, in respect of god, merely negations, but, in respect of ourselves, privations.</p>
+							<p epub:type="bridgehead">That our errors are, in respect of God, merely negations, but, in respect of ourselves, privations.</p>
 						</header>
 						<p>But as it happens that we frequently fall into error, although God is no deceiver, if we desire to inquire into the origin and cause of our errors, with a view to guard against them, it is necessary to observe that they depend less on our understanding than on our will, and that they have no need of the actual concourse of God, in order to their production; so that, when considered in reference to God, they are merely negations, but in reference to ourselves, privations.</p>
 					</section>
@@ -300,7 +300,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-36" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXXVI</h5>
-							<p epub:type="bridgehead">That our errors cannot be imputed to god.</p>
+							<p epub:type="bridgehead">That our errors cannot be imputed to God.</p>
 						</header>
 						<p>But although God has not given us an omniscient understanding, he is not on this account to be considered in any wise the author of our errors, for it is of the nature of created intellect to be finite, and of finite intellect not to embrace all things.</p>
 					</section>
@@ -314,7 +314,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-38" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XXXVIII</h5>
-							<p epub:type="bridgehead">That error is a defect in our mode of acting, not in our nature; and that the faults of their subjects may be frequently attributed to other masters, but never to god.</p>
+							<p epub:type="bridgehead">That error is a defect in our mode of acting, not in our nature; and that the faults of their subjects may be frequently attributed to other masters, but never to God.</p>
 						</header>
 						<p>It is true, that as often as we err, there is some defect in our mode of action or in the use of our liberty, but not in our nature, because this is always the same, whether our judgments be true or false. And although God could have given to us such perspicacity of intellect that we should never have erred, we have, notwithstanding, no right to demand this of him; for, although with us he who was able to prevent evil and did not is held guilty of it, God is not in the same way to be reckoned responsible for our errors because he had the power to prevent them, inasmuch as the dominion which some men possess over others has been instituted for the purpose of enabling them to hinder those under them from doing evil, whereas the dominion which God exercises over the universe is perfectly absolute and free. For this reason we ought to thank him for the goods he has given us, and not complain that he has not blessed us with all which we know it was in his power to impart.</p>
 					</section>
@@ -328,7 +328,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-40" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">XL</h5>
-							<p epub:type="bridgehead">That it is likewise certain that god has foreordained all things.</p>
+							<p epub:type="bridgehead">That it is likewise certain that God has foreordained all things.</p>
 						</header>
 						<p>But because what we have already discovered of God, gives us the assurance that his power is so immense that we would sin in thinking ourselves capable of ever doing anything which he had not ordained beforehand, we should soon be embarrassed in great difficulties if we undertook to harmonise the preordination of God with the freedom of our will, and endeavoured to comprehend both truths at once.</p>
 					</section>
@@ -405,7 +405,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-51" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">LI</h5>
-							<p epub:type="bridgehead">What substance is, and that the term is not applicable to god and the creatures in the same sense.</p>
+							<p epub:type="bridgehead">What substance is, and that the term is not applicable to God and the creatures in the same sense.</p>
 						</header>
 						<p>But with regard to what we consider as things or the modes of things, it is worth while to examine each of them by itself. By substance we can conceive nothing else than a thing which exists in such a way as to stand in need of nothing beyond itself in order to its existence. And, in truth, there can be conceived but one substance which is absolutely independent, and that is God. We perceive that all other things can exist only by help of the concourse of God. And, accordingly, the term substance does not apply to God and the creatures <em>univocally</em>, to adopt a term familiar in the schools; that is, no signification of this word can be distinctly understood which is common to God and them.</p>
 					</section>
@@ -426,7 +426,7 @@
 					<section id="selections-from-the-principles-of-philosophy-1-54" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">LIV</h5>
-							<p epub:type="bridgehead">How we may have clear and distinct notions of the substance which thinks, of that which is corporeal, and of god.</p>
+							<p epub:type="bridgehead">How we may have clear and distinct notions of the substance which thinks, of that which is corporeal, and of God.</p>
 						</header>
 						<p>And thus we may easily have two clear and distinct notions or ideas, the one of created substance, which thinks, the other of corporeal substance, provided we carefully distinguish all the attributes of thought from those of extension. We may also have a clear and distinct idea of an uncreated and independent thinking substance, that is, of God, provided we do not suppose that this idea adequately represents to us all that is in God, and do not mix up with it anything fictitious, but attend simply to the characters that are comprised in the notion we have of him, and which we clearly know to belong to the nature of an absolutely perfect Being. For no one can deny that there is in us such an idea of God, without groundlessly supposing that there is no knowledge of God at all in the human mind.</p>
 					</section>
@@ -780,14 +780,14 @@
 					<section id="selections-from-the-principles-of-philosophy-3-1" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">I</h5>
-							<p epub:type="bridgehead">That we cannot think too highly of the works of god.</p>
+							<p epub:type="bridgehead">That we cannot think too highly of the works of God.</p>
 						</header>
 						<p>Having now ascertained certain principles of material things, which were sought, not by the prejudices of the senses, but by the light of reason, and which thus possess so great evidence that we cannot doubt of their truth, it remains for us to consider whether from these alone we can deduce the explication of all the phenomena of nature. We will commence with those phenomena that are of the greatest generality, and upon which the others depend, as, for example, with the general structure of this whole visible world. But in order to our philosophizing aright regarding this, two things are first of all to be observed. The first is, that we should ever bear in mind the infinity of the power and goodness of God, that we may not fear falling into error by imagining his works to be too great, beautiful, and perfect, but that we may, on the contrary, take care lest, by supposing limits to them of which we have no certain knowledge, we appear to think less highly than we ought of the power of God.</p>
 					</section>
 					<section id="selections-from-the-principles-of-philosophy-3-2" epub:type="chapter">
 						<header>
 							<h5 epub:type="ordinal z3998:roman">II</h5>
-							<p epub:type="bridgehead">That we ought to beware lest, in our presumption, we imagine that the ends which god proposed to himself in the creation of the world are understood by us.</p>
+							<p epub:type="bridgehead">That we ought to beware lest, in our presumption, we imagine that the ends which God proposed to himself in the creation of the world are understood by us.</p>
 						</header>
 						<p>The second is, that we should beware of presuming too highly of ourselves, as it seems we should do if we supposed certain limits to the world, without being assured of their existence either by natural reasons or by divine revelation, as if the power of our thought extended beyond what God has in reality made; but likewise still more if we persuaded ourselves that all things were created by God for us only, or if we merely supposed that we could comprehend by the power of our intellect the ends which God proposed to himself in creating the universe.</p>
 					</section>


### PR DESCRIPTION
When converting these bridgeheads from titlecase to sentence case during the review I accidentally changed all instances of "God" to "god"; this fixes that.